### PR TITLE
Change interrupt pin to 18 (GPIO 24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ RFM pin - Pi pin
 DIO0    - 18 (GPIO24)  
 MOSI    - 19  
 MISO    - 21  
-CLK     - 23  
+CLK     - 23
+NSS     - 24
 Ground  - 25  
 
 You can change the interrupt pin (GPIO24) in the class init.  

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ RFM pin - Pi pin
 DIO0    - 18 (GPIO24)  
 MOSI    - 19  
 MISO    - 21  
-CLK     - 23
-NSS     - 24
+CLK     - 23  
+NSS     - 24  
 Ground  - 25  
 
 You can change the interrupt pin (GPIO24) in the class init.  

--- a/RFM69.py
+++ b/RFM69.py
@@ -6,7 +6,7 @@ import RPi.GPIO as GPIO
 import time
 
 class RFM69():
-  def __init__(self, freqBand, nodeID, networkID, isRFM69HW = False, intPin = 24):
+  def __init__(self, freqBand, nodeID, networkID, isRFM69HW = False, intPin = 18):
 
     self.freqBand = freqBand
     self.address = nodeID


### PR DESCRIPTION
README updated to reflect pin 24 (GPIO 8/CE0) is used to establish the SPI link

Resolves #1 
