### PR TITLE
Fix apparent typo in shebang

### DIFF
--- a/RFM69.py
+++ b/RFM69.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python2
+#!/usr/bin/env python2
 
 from RFM69registers import *
 import spidev


### PR DESCRIPTION
Without this change, attempting to execute `./RFM69.py` will yield the following error message: `-bash: ./RFM69.py: /usr/bin/env/python2: bad interpreter: Not a directory`
