### PR TITLE
Updated RFM69.py to stop process spinning and using large amounts of CPU

### DIFF
--- a/RFM69.py
+++ b/RFM69.py
@@ -28,6 +28,7 @@ class RFM69(object):
         self.ACK_RECEIVED = 0
         self.RSSI = 0
         self.DATA = []
+        self.sendSleepTime = 0.05
 
         GPIO.setmode(GPIO.BOARD)
         GPIO.setup(self.intPin, GPIO.IN)
@@ -244,11 +245,13 @@ class RFM69(object):
         else:
             self.spi.xfer2([REG_FIFO | 0x80, len(buff) + 3, toAddress, self.address, ack] + buff)
 
-        startTime = time.time()
         self.DATASENT = False
         self.setMode(RF69_MODE_TX)
+        slept = 0
         while not self.DATASENT:
-            if time.time() - startTime > 1.0:
+            time.sleep(self.sendSleepTime)
+            slept += self.sendSleepTime
+            if slept > 1.0:
                 break
         self.setMode(RF69_MODE_RX)
 


### PR DESCRIPTION
Removed spinning in sendFrame using large amounts of processor time. When using for sending repeated messages for OTA updating (using my own logic) it reduced the CPU utilization from 50%+ at points to 3%.