### PR TITLE
Make gpioMode a parameter for RFM69

### DIFF
--- a/RFM69.py
+++ b/RFM69.py
@@ -6,7 +6,7 @@ import RPi.GPIO as GPIO
 import time
 
 class RFM69(object):
-    def __init__(self, freqBand, nodeID, networkID, isRFM69HW = False, intPin = 18, rstPin = 28, spiBus = 0, spiDevice = 0):
+    def __init__(self, freqBand, nodeID, networkID, isRFM69HW = False, intPin = 18, rstPin = 28, spiBus = 0, spiDevice = 0, gpioMode = GPIO.BOARD):
 
         self.freqBand = freqBand
         self.address = nodeID
@@ -30,7 +30,7 @@ class RFM69(object):
         self.DATA = []
         self.sendSleepTime = 0.05
 
-        GPIO.setmode(GPIO.BOARD)
+        GPIO.setmode(gpioMode)
         GPIO.setup(self.intPin, GPIO.IN)
         GPIO.setup(self.rstPin, GPIO.OUT)
 


### PR DESCRIPTION
When working with other gpio libraries in the same program, they sometimes try to set different gpioModes and end up erroring out. Making it a parameter makes this library easier to work with others.