### PR TITLE
Move reset pin from pin 28 (reserved) to pin 29.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Attach the RFM69 as follows:
 | CLK     | 23  
 | NSS     | 24  
 | Ground  | 25  
-| RESET   | 28
+| RESET   | 29
 
 You can change the interrupt pin (GPIO24) in the class init.
 

--- a/RFM69.py
+++ b/RFM69.py
@@ -6,7 +6,7 @@ import RPi.GPIO as GPIO
 import time
 
 class RFM69(object):
-    def __init__(self, freqBand, nodeID, networkID, isRFM69HW = False, intPin = 18, rstPin = 28, spiBus = 0, spiDevice = 0):
+    def __init__(self, freqBand, nodeID, networkID, isRFM69HW = False, intPin = 18, rstPin = 29, spiBus = 0, spiDevice = 0):
 
         self.freqBand = freqBand
         self.address = nodeID


### PR DESCRIPTION
Pin 28 is reserved for I2C communication with Raspberry Pi Hats.
Other projects use Pin 29 for the reset line. This commit adapts to this "standard".

Fixes #34