### PR TITLE
fix race condition with receiving messages

### DIFF
--- a/RFM69.py
+++ b/RFM69.py
@@ -206,6 +206,7 @@ class RFM69(object):
             sentTime = time.time()
             while (time.time() - sentTime) * 1000 < retryWaitTime:
                 if self.ACKReceived(toAddress):
+                    self.receiveBegin()
                     return True
         return False
 
@@ -295,6 +296,8 @@ class RFM69(object):
         self.setMode(RF69_MODE_RX)
 
     def receiveDone(self):
+        while self.intLock:
+            pass # wait for lock to be removed
         if (self.mode == RF69_MODE_RX or self.mode == RF69_MODE_STANDBY) and self.PAYLOADLEN > 0:
             self.setMode(RF69_MODE_STANDBY)
             return True
@@ -303,10 +306,6 @@ class RFM69(object):
             # Russss figured out that if you leave alone long enough it times out
             # tell it to stop being silly and listen for more packets
             self.writeReg(REG_PACKETCONFIG2, (self.readReg(REG_PACKETCONFIG2) & 0xFB) | RF_PACKET2_RXRESTART)
-        elif self.mode == RF69_MODE_RX:
-            # already in RX no payload yet
-            return False
-        self.receiveBegin()
         return False
 
     def readRSSI(self, forceTrigger = False):

--- a/example.py
+++ b/example.py
@@ -23,12 +23,13 @@ print "sending blah to 2"
 if test.sendWithRetry(2, "blah", 3, 20):
     print "ack recieved"
 print "reading"
+test.receiveBegin()
 while True:
-    test.receiveBegin()
-    while not test.receiveDone():
-        time.sleep(.1)
-    print "%s from %s RSSI:%s" % ("".join([chr(letter) for letter in test.DATA]), test.SENDERID, test.RSSI)
-    if test.ACKRequested():
-        test.sendACK()
+    if test.receiveDone():
+        print "%s from %s RSSI:%s" % ("".join([chr(letter) for letter in test.DATA]), test.SENDERID, test.RSSI)
+        if test.ACKRequested():
+            test.sendACK()
+        else:
+            test.receiveBegin()
 print "shutting down"
 test.shutdown()


### PR DESCRIPTION
We no longer call receiveBegin() from inside receiveDone() if no data's
ready. Previously, if interruptHandler triggerred while receiveDone()
was processing, receiveBegin() would wipe out the received data. This
could be mitigated with sleeps between loops to decrease the odds of
such a scenario, but it's far more reliable to just let the user
explicitly call receiveBegin() once they have processed the latest
message. This should fix issue #29