### PR TITLE
Fixes #44: Frequency setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Description
 
-This is a port of the RFM69 library for arduino from https://github.com/LowPowerLab/RFM69 to python for raspberry pi.
+This is a port of the RFM69 library for Arduino from https://github.com/LowPowerLab/RFM69 to Python for the Raspberry Pi and Orange Pi.
 
 # Hardware setup
 
@@ -12,19 +12,98 @@ Attach the RFM69 as follows:
 
 | RFM pin | Pi pin  
 | ------- |-------
-| 3v3     | 17  
+| 3V3     | 17  
 | DIO0    | 18 (GPIO24)  
 | MOSI    | 19  
 | MISO    | 21  
 | CLK     | 23  
-| NSS     | 24  
+| NSS     | 24 (CE0)  
 | Ground  | 25  
-| RESET   | 29
+| RESET   | 22 (GPIO25)  
 
-You can change the interrupt pin (GPIO24) in the class init.
+You can change the interrupt and reset pins in the class init.
 
-Remember to choose correct frequency for your hardware (315, 433, 868 or 915 MHz).
+Remember to choose a correct frequency for your hardware (315, 433, 868 or 915 MHz).
 
 # Prerequisites
 
-RPi.GPIO and spidev
+The following Python packages must be installed for the Raspberry Pi (using pip3):
+
+* RPi.GPIO
+* spidev
+
+For Orange Pi, these packages are required instead:
+
+* OrangePi.GPIO
+* spidev
+
+Be sure to enable the SPI interface on your GPIO header using either the command `raspi-config` or `armbian-config`.
+Orange Pi systems running Armbian also require this extra step to enable the SPI bus:
+Edit the file /boot/armbianEnv.txt and insert the line
+
+    param_spidev_spi_bus=1
+
+after the existing line similar to
+
+    overlays=spi-spidev
+
+Then reboot the system in any case.
+
+You can use this SPI test program to verify that SPI is set up properly: https://github.com/rm-hull/spidev-test
+
+The code in this repository is configured for the Raspberry Pi.
+To use this on an Orange Pi, follow the instructions in the file RFM69.py to change the imported package name, SPI bus (1 instead of 0) and tell the GPIO package the board type you have (preconfigured to Orange Pi Zero).
+
+# Simple usage
+
+The example.py script shows some method calls. Its function isn't necessarily meaningful.
+
+The scripts radio1.py and radio2.py are set up to talk to each other in a ping pong style.
+They can be used to test the communication between two nodes, for specific antenna setup, power level and modulation parameters.
+Both scripts are almost identical, just the definitions at the top differ to give both their identity.
+Run one on one device and the other on another device, both connected to an RFM69 module for the same frequency range.
+The scripts will print each received message with its RSSI to indicate how strong the received signal was.
+
+Before running any of these scripts, be sure to review them and make necessary changes, like the RF frequency or H-model type.
+
+Class initialisation:
+
+    radio = RFM69.RFM69(RF69_433MHZ, node_id, network_id, is_rfm_69HW)
+
+This creates a new instance of the class that you can use to call methods on.
+
+    radio.setHighPower(True)
+
+This must be called on any RFM69 device with an "H" in its model (for high power), otherwise it won't send anything.
+It's the same condition as the `is_rfm_69HW` parameter above.
+
+    radio.encrypt("1234567890123xyz")
+
+This will set up the embedded AES encryption.
+The key must be exactly 16 ASCII characters and of course it must be the same for each node that should talk to each other because AES is a symmetric cipher.
+
+    radio.setFrequency(433500000)
+
+This must be called in any case to set the actual frequency to transmit and receive on.
+The number is in Hz but the resolution is only about 61 Hz.
+This example sets the frequency to 433.5 MHz.
+
+    radio.send(2, "Hello world")
+    radio.sendWithRetry(2, "Hello world", 3, 100)
+
+This call sends a message "Hello world" to the node 2.
+The second one also waits for an acknowledgement within 100 milliseconds and, if none was received, resends the message for a total of up to 3 times.
+
+Additional methods can be called to start receiving messages, handle ACKs, set the modulation parameters, or shut down the device.
+You should always call the shutdown method so that the radio module isn't kept in an active state when you're no longer using it.
+The sample scripts show a method how to do this in Python with try/except.
+
+Setting the transmit power level is currently incomplete and needs some rework.
+It can only access some of the available levels on H-models, see the [original code issue](https://github.com/LowPowerLab/RFM69/issues/61).
+(This Python port has a slightly different implementation, but still incomplete.)
+It is currently possible with this call:
+
+    radio.setPowerLevel(0)
+
+Set the number to a value between 0 and 31.
+Due to the limitations, probably only the values 0 and 31 are useful now, for minimum and maximum output power, respectively.

--- a/RFM69registers.py
+++ b/RFM69registers.py
@@ -1083,7 +1083,7 @@ RF69_MODE_SLEEP = 0 # XTAL OFF
 RF69_MODE_STANDBY = 1 # XTAL ON
 RF69_MODE_SYNTH	= 2 # PLL ON
 RF69_MODE_RX = 3 # RX MODE
-RF69_MODE_TX	= 4 # TX MODE
+RF69_MODE_TX = 4 # TX MODE
 
 COURSE_TEMP_COEF = -90 # puts the temperature reading in the ballpark, user can fine tune the returned value
 RF69_BROADCAST_ADDR = 255

--- a/example.py
+++ b/example.py
@@ -9,30 +9,49 @@ network_id = 1
 node_id = 1
 is_rfm_69HW = True
 
-test = RFM69.RFM69(RF69_915MHZ, node_id, network_id, is_rfm_69HW)
+radio = RFM69.RFM69(RF69_433MHZ, node_id, network_id, is_rfm_69HW)
 print("class initialized")
 print("reading all registers")
-results = test.readAllRegs()
+results = radio.readAllRegs()
 for result in results:
     print(result)
 print("Performing rcCalibration")
-test.rcCalibration()
+radio.rcCalibration()
 print("setting high power")
-test.setHighPower(True)
+radio.setHighPower(True)
+#radio.setPowerLevel(31)
 print("Checking temperature")
-print(test.readTemperature(0))
+print(radio.readTemperature(0))
 print("setting encryption")
-test.encrypt("1234567891011121")
-print("sending blah to 2")
-if test.sendWithRetry(2, "blah", 3, 20):
-    print("ack recieved")
+radio.encrypt("1234567890123456")
+
+radio.setFrequency(433500000)
+
+radio.writeReg(REG_BITRATEMSB, RF_BITRATEMSB_1200)
+radio.writeReg(REG_BITRATELSB, RF_BITRATELSB_1200)
+
+radio.writeReg(REG_FDEVMSB, RF_FDEVMSB_5000)
+radio.writeReg(REG_FDEVLSB, RF_FDEVLSB_5000)
+
+freq = radio.getFrequency()
+print(f"frequency set to {freq / 1000000} MHz")
+
+print("sending to 2")
+if radio.sendWithRetry(2, "012345678901234567890123456789012345678901234567890123456789", 3, 100):
+    print("ack received")
+time.sleep(0.5)
 print("reading")
-while True:
-    test.receiveBegin()
-    while not test.receiveDone():
-        time.sleep(.1)
-    print("%s from %s RSSI:%s" % ("".join([chr(letter) for letter in test.DATA]), test.SENDERID, test.RSSI))
-    if test.ACKRequested():
-        test.sendACK()
+try:
+    while True:
+        radio.receiveBegin()
+        while not radio.receiveDone():
+            time.sleep(.1)
+        print("%s from %s RSSI:%s" % ("".join([chr(letter) for letter in radio.DATA]), radio.SENDERID, radio.RSSI))
+        if radio.ACKRequested():
+            radio.sendACK()
+except KeyboardInterrupt:
+    # Clean up properly to not leave GPIO/SPI in an unusable state
+    pass
+
 print("shutting down")
-test.shutdown()
+radio.shutdown()

--- a/example.py
+++ b/example.py
@@ -40,7 +40,7 @@ print("sending to 2")
 if radio.sendWithRetry(2, "012345678901234567890123456789012345678901234567890123456789", 3, 100):
     print("ack received")
 time.sleep(0.5)
-print("reading")
+print("reading (interrupt to stop)")
 try:
     while True:
         radio.receiveBegin()

--- a/radio2.py
+++ b/radio2.py
@@ -5,17 +5,18 @@ from RFM69registers import *
 import datetime
 import time
 
-NODE=2
-NET=1
-KEY="1234567891011121"
-TIMEOUT=3
-TOSLEEP=0.1
+NODE = 2
+OTHERNODE = 1
+NET = 1
+KEY = "1234567890123456"
+TIMEOUT = 6
+TOSLEEP = 0.1
 
-radio = RFM69.RFM69(RF69_915MHZ, NODE, NET, True)
+radio = RFM69.RFM69(RF69_433MHZ, NODE, NET, True)
 print("class initialized")
 
-print("reading all registers")
-results = radio.readAllRegs()
+#print("reading all registers")
+#results = radio.readAllRegs()
 #for result in results:
 #    print(result)
 
@@ -24,6 +25,7 @@ radio.rcCalibration()
 
 print("setting high power")
 radio.setHighPower(True)
+#radio.setPowerLevel(0)
 
 print("Checking temperature")
 print(radio.readTemperature(0))
@@ -31,35 +33,48 @@ print(radio.readTemperature(0))
 print("setting encryption")
 radio.encrypt(KEY)
 
-sequence=0
+radio.setFrequency(433500000)
+
+radio.writeReg(REG_BITRATEMSB, RF_BITRATEMSB_1200)
+radio.writeReg(REG_BITRATELSB, RF_BITRATELSB_1200)
+
+radio.writeReg(REG_FDEVMSB, RF_FDEVMSB_5000)
+radio.writeReg(REG_FDEVLSB, RF_FDEVLSB_5000)
+
 print("starting loop...")
-while True:
+sequence = 0
+try:
+    while True:
+        msg = "I'm radio %d: %d" % (NODE, sequence)
+        sequence += 1
 
+        print(f"TX >> {OTHERNODE}: {msg}")
+        if radio.sendWithRetry(OTHERNODE, msg, 3, 500):
+            print("ACK received")
 
-    msg = "I'm radio %d: %d" % (NODE, sequence)
-    sequence = sequence + 1
+        print("receiving...")
+        radio.receiveBegin()
+        timedOut = 0
+        while not radio.receiveDone():
+            timedOut += TOSLEEP
+            time.sleep(TOSLEEP)
+            if timedOut > TIMEOUT:
+                print("nothing received")
+                break
 
-    print("tx to radio 1: " + msg)
-    if radio.sendWithRetry(1, msg, 3, 20):
-        print("ack recieved")
-
-    print("starting recv...")
-    radio.receiveBegin()
-    timedOut=0
-    while not radio.receiveDone():
-        timedOut+=TOSLEEP
-        time.sleep(TOSLEEP)
-        if timedOut > TIMEOUT:
-            print("timed out waiting for recv")
-            break
-
-    print("end recv...")
-    print(" ### %s from %s RSSI:%s " % ("".join([chr(letter) for letter in radio.DATA]), radio.SENDERID, radio.RSSI))
-
-    if radio.ACKRequested():
-        radio.sendACK()
-    else:
-        print("ack not requested...")
+        if timedOut <= TIMEOUT:
+            sender = radio.SENDERID
+            msg = "".join([chr(letter) for letter in radio.DATA])
+            ackReq = radio.ACKRequested()
+            print(f"RX << {sender}: {msg} (RSSI: {radio.RSSI})")
+            if ackReq:
+                print("sending ACK...")
+                time.sleep(0.05)
+                radio.sendACK()
+            time.sleep(TIMEOUT / 2)
+except KeyboardInterrupt:
+    # Clean up properly to not leave GPIO/SPI in an unusable state
+    pass
 
 print("shutting down")
 radio.shutdown()


### PR DESCRIPTION
- Fixed typo of setFrequency method
- New method takes frequency in Hz instead of a precalculated raw value
- Added getFrequency method
- Added support for Orange Pi boards (tested with Orange Pi Zero) (see #14)
- Changed default GPIO pin for reset on a pin closer to the others and available on Orange Pi (see #34)
- Changed timings and added short delay to improve stability on a Linux computer (not real-time)
- Updated radio1/2 scripts for more readable output, stable timings and to be cancellable (fixes #24)
- Fixed some typos in comments